### PR TITLE
feat(v0.10.0): claude-recall scrub-images for oversized-image session recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,101 @@
 
 All notable changes to `claude-recall`. Format: one section per tag.
 
+## v0.10.0 — 2026-06-11
+
+`claude-recall scrub-images` — replace oversized image content blocks
+in session jsonls with text placeholders. Unblocks sessions rejected
+by the Anthropic many-image dimension limit (2000px) without
+abandoning the conversation.
+
+### Background
+
+The Anthropic API enforces a 2000px-on-any-dimension limit when a
+conversation has multiple images. Once an oversized image lands in a
+session transcript, every subsequent request fails with:
+
+> An image in the conversation exceeds the dimension limit for
+> many-image requests (2000px). Start a new session with fewer images.
+
+The error message's suggested fix — start a new session — drops the
+conversation context. For a long-running session that's a real cost.
+
+OC hit this exactly during a PhysicianAssistant session on 2026-06-11
+after two tool-result screenshots came back at 2048x2048. The session
+was wedged; manual surgical editing of the jsonl unblocked it. That
+manual procedure is the implementation reference for this command.
+
+### What `scrub-images` does
+
+```bash
+# Scope to the current project (default behavior — derives slug from cwd).
+claude-recall scrub-images
+
+# Scope to a specific project, or 'all' projects.
+claude-recall scrub-images --project e--dev-work-PhysicianAssistant
+claude-recall scrub-images --project all
+
+# Limit to one session by UUID prefix.
+claude-recall scrub-images --session 69811251
+
+# Preview without writing.
+claude-recall scrub-images --dry-run
+
+# Override thresholds.
+claude-recall scrub-images --max-dim 1500 --max-bytes 1048576
+```
+
+The command walks every session jsonl in scope, base64-decodes image
+content blocks (including those nested inside `tool_result` blocks),
+reads PNG/JPEG dimensions and byte size, and for each image that
+exceeds either threshold:
+
+- Replaces the image block in place with a text block reading
+  `[image removed by claude-recall scrub-images: WxH (N bytes)
+  exceeded limits (...)]`.
+- Preserves the enclosing `tool_result` / `message.content`
+  structure so `tool_use_id` linkage stays intact (no orphan
+  tool_use blocks; resume works without API rejection).
+- Blanks `toolUseResult.file.base64` (Claude Code metadata, not part
+  of the API conversation) to free up disk in addition to fixing
+  the API rejection.
+
+### Safety
+
+- A `.bak.<timestamp>` sidecar is written before any modification.
+  Skip with `--no-backup` if you don't want the disk overhead.
+- Writes are atomic (temp file then `os.replace`).
+- Idempotent: the canonical placeholder is detected on subsequent
+  runs and skipped, so re-running is safe.
+- `--dry-run` reports findings without touching any file.
+
+### Detection details
+
+- PNG dimensions read from the IHDR chunk (bytes 16-24, big-endian
+  uint32 pair). The PNG signature (`\x89PNG\r\n\x1a\n`) gates the
+  parse to avoid mis-identifying other formats.
+- JPEG dimensions read from the first SOFn marker (excluding DHT
+  0xC4, DAC 0xCC, DNL 0xC8 which share the SOFn marker range but
+  are not start-of-frame).
+- Other image formats (GIF, WebP, etc.) are not currently parsed
+  for dimensions but will be caught by the `--max-bytes` threshold.
+
+### Threshold defaults
+
+- `--max-dim 2000` — matches Anthropic's many-image limit as of
+  June 2026.
+- `--max-bytes 5242880` (5 MiB) — generous default. Tighten if a
+  particular session has bytes-heavy images near but under 2000px.
+
+### What `scrub-images` does NOT do
+
+- Does not re-index the session in claude-recall's DB. The indexer
+  already tolerates jsonl edits — re-run `claude-recall index` if
+  you want to reflect the scrubbed state in the search index.
+- Does not delete entire turns. The substitution preserves
+  conversation structure rather than removing the turn outright,
+  which is safer for resume.
+
 ## v0.9.2 — 2026-05-21
 
 `claude-recall doctor` — diagnose hook wiring drift in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-recall"
-version = "0.9.2"
+version = "0.10.0"
 description = "Automatic, cheap, precise query of Claude Code session archives via SQLite FTS5 + hooks."
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/claude_recall/__init__.py
+++ b/src/claude_recall/__init__.py
@@ -3,6 +3,6 @@
 See docs/PLAN.md for the implementation plan.
 """
 
-__version__ = "0.9.2"
+__version__ = "0.10.0"
 __author__ = "Mark McArthey"
 __license__ = "MIT"

--- a/src/claude_recall/cli.py
+++ b/src/claude_recall/cli.py
@@ -297,6 +297,46 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    # scrub-images (v0.10.0)
+    p_scrub = sub.add_parser(
+        "scrub-images",
+        help=(
+            "Replace oversized images in session jsonls with text "
+            "placeholders. Unblocks sessions rejected by the Anthropic "
+            "many-image dimension limit (2000px)."
+        ),
+    )
+    p_scrub.add_argument(
+        "--project",
+        help=(
+            "Scope to one project slug (default: derive from the current "
+            "directory; pass 'all' to scan every project)."
+        ),
+    )
+    p_scrub.add_argument(
+        "--session",
+        help=(
+            "Limit to sessions whose UUID stem starts with this prefix "
+            "(e.g. '69811251'). Combine with --project to scope tightly."
+        ),
+    )
+    p_scrub.add_argument(
+        "--max-dim", type=int, default=2000,
+        help="Pixel dimension threshold (default: 2000, per Anthropic many-image limit).",
+    )
+    p_scrub.add_argument(
+        "--max-bytes", type=int, default=5 * 1024 * 1024,
+        help="Byte-size threshold for individual images (default: 5 MiB).",
+    )
+    p_scrub.add_argument(
+        "--dry-run", action="store_true",
+        help="Report findings without modifying any files.",
+    )
+    p_scrub.add_argument(
+        "--no-backup", action="store_true",
+        help="Skip the .bak.<timestamp> sidecar that's written before any modification.",
+    )
+
     # reclassify (v0.8.4)
     p_reclassify = sub.add_parser(
         "reclassify",
@@ -357,6 +397,7 @@ def main(argv: list[str] | None = None) -> int:
         "reclassify": _cmd_reclassify,
         "emit-prompt-context": _cmd_emit_prompt_context,
         "doctor": _cmd_doctor,
+        "scrub-images": _cmd_scrub_images,
     }
     return handlers[args.command](args, cfg)
 
@@ -742,6 +783,40 @@ def _cmd_doctor(args: argparse.Namespace, cfg: Config) -> int:
         return 2
     if report.has_warnings:
         return 1
+    return 0
+
+
+# --- scrub-images -----------------------------------------------------------
+
+def _cmd_scrub_images(args: argparse.Namespace, cfg: Config) -> int:
+    """Replace oversized image content in session jsonls.
+
+    Project scoping:
+    - ``--project all`` walks every project under the archive root.
+    - ``--project <slug>`` walks only that project's archive directory.
+    - Otherwise, derive the slug from cwd via ``projects.slug_from_path``.
+    """
+    from . import scrub_images as _scrub
+    from . import projects as _projects
+
+    project_slug: str | None
+    if args.project == "all":
+        project_slug = None
+    elif args.project:
+        project_slug = args.project
+    else:
+        project_slug = _projects.slug_from_path(Path.cwd().absolute())
+
+    report = _scrub.run_scrub(
+        cfg.archive_root,
+        project_slug=project_slug,
+        session_id_prefix=args.session,
+        max_dim_px=args.max_dim,
+        max_bytes=args.max_bytes,
+        dry_run=args.dry_run,
+        backup=not args.no_backup,
+    )
+    print(_scrub.format_report(report, dry_run=args.dry_run))
     return 0
 
 

--- a/src/claude_recall/scrub_images.py
+++ b/src/claude_recall/scrub_images.py
@@ -1,0 +1,430 @@
+"""Scrub oversized images out of session jsonls (v0.10.0).
+
+The Anthropic API enforces a 2000px-on-any-dimension limit when a
+conversation has multiple images ("many-image requests"). Once an
+oversized image is in the session transcript, every subsequent request
+fails with::
+
+  An image in the conversation exceeds the dimension limit for
+  many-image requests (2000px). Start a new session with fewer images.
+
+The user-visible fix the error suggests — start a new session — drops
+the conversation. `claude-recall scrub-images` is the surgical fix:
+walk the project's session jsonls, find image content blocks exceeding
+the limit, replace each one with a text placeholder that keeps the
+`tool_use_id` linkage intact. The session resumes cleanly with the
+oversized images gone and the rest of the history preserved.
+
+Detection:
+
+- PNG dimensions read from the IHDR chunk (bytes 16-24).
+- JPEG dimensions read from the first SOFn marker (excluding DHT/DAC/DNL).
+- Base64-decode happens on demand; non-image content is skipped.
+- Recursive walk catches images nested inside ``tool_result`` content
+  blocks (the common case — screenshots returned from Read tool calls).
+
+Scrubbing:
+
+- Each oversized image is replaced with a single text block reading
+  ``[image removed by claude-recall scrub-images: <WxH> exceeded
+  <limit>px many-image limit]``.
+- The enclosing ``tool_result`` / ``message.content`` structure is
+  preserved so resume works without orphan ``tool_use`` blocks.
+- ``toolUseResult.file.base64`` (Claude Code-side metadata, not part
+  of the API conversation) is also blanked to reduce file size.
+- Writes are atomic: temp file then ``os.replace``.
+- A ``.bak.<timestamp>`` sidecar is written before any modification
+  unless ``--no-backup`` is passed.
+
+Idempotency:
+
+- The text placeholder is detected on re-runs and skipped, so running
+  ``scrub-images`` repeatedly is safe and a no-op after the first
+  successful pass.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import os
+import shutil
+import struct
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator
+
+from .projects import slug_from_path
+
+PLACEHOLDER_PREFIX = "[image removed by claude-recall scrub-images:"
+
+# Anthropic's many-image dimension limit (Jun 2026).
+DEFAULT_MAX_DIM_PX = 2000
+
+# Soft byte cap: catches base64 payloads that decode under 2000px but
+# are unusually large (e.g., near-uncompressed PNGs at 1990x1990). Set
+# generously; can be tightened per-invocation.
+DEFAULT_MAX_BYTES = 5 * 1024 * 1024  # 5 MiB
+
+
+@dataclass
+class ImageFinding:
+    """One oversized image found in a session jsonl."""
+
+    session_path: Path
+    line_number: int
+    width: int | None
+    height: int | None
+    byte_size: int
+    reason: str             # "dimension" | "byte_size" | "both"
+    timestamp: str = ""     # the turn's timestamp from the jsonl, if present
+
+
+@dataclass
+class ScrubReport:
+    """Outcome of one scrub-images run."""
+
+    sessions_scanned: int = 0
+    sessions_modified: int = 0
+    images_scanned: int = 0
+    images_scrubbed: int = 0
+    findings: list[ImageFinding] = field(default_factory=list)
+    skipped_already_scrubbed: int = 0
+    parse_errors: list[tuple[Path, int, str]] = field(default_factory=list)
+
+    @property
+    def had_changes(self) -> bool:
+        return self.images_scrubbed > 0
+
+
+def png_dimensions(data: bytes) -> tuple[int, int] | None:
+    """Return (width, height) of a PNG, or None if not a valid PNG.
+
+    PNG signature is 8 bytes followed by the IHDR chunk whose payload
+    starts at byte 16 with two big-endian uint32s for width and height.
+    """
+    if len(data) < 24 or data[:8] != b"\x89PNG\r\n\x1a\n":
+        return None
+    try:
+        width, height = struct.unpack(">II", data[16:24])
+    except struct.error:
+        return None
+    return width, height
+
+
+def jpeg_dimensions(data: bytes) -> tuple[int, int] | None:
+    """Return (width, height) of a JPEG, or None if not a valid JPEG.
+
+    Scans the segment chain for the first SOFn marker that carries
+    dimensions. SOF0/1/2/3/5/6/7/9/10/11/13/14/15 all encode dimensions
+    identically; we exclude DHT (0xC4), DAC (0xCC), and DNL (0xC8)
+    which share the SOFn range but are not start-of-frame.
+    """
+    if len(data) < 4 or data[:2] != b"\xff\xd8":
+        return None
+    i = 2
+    n = len(data)
+    while i < n - 9:
+        if data[i] != 0xFF:
+            i += 1
+            continue
+        # Skip fill bytes (0xFF followed by 0xFF).
+        while i < n - 1 and data[i + 1] == 0xFF:
+            i += 1
+        if i >= n - 1:
+            return None
+        marker = data[i + 1]
+        if 0xC0 <= marker <= 0xCF and marker not in (0xC4, 0xC8, 0xCC):
+            # SOFn: 2 marker bytes + 2 length + 1 precision + 2 height + 2 width
+            if i + 9 > n:
+                return None
+            height, width = struct.unpack(">HH", data[i + 5 : i + 9])
+            return width, height
+        # Non-frame marker — skip its segment.
+        if i + 4 > n:
+            return None
+        seg_len = struct.unpack(">H", data[i + 2 : i + 4])[0]
+        i += 2 + seg_len
+    return None
+
+
+def image_dimensions(data: bytes) -> tuple[int, int] | None:
+    """Return (width, height) for PNG or JPEG bytes, else None."""
+    dims = png_dimensions(data)
+    if dims is not None:
+        return dims
+    return jpeg_dimensions(data)
+
+
+def _iter_image_blocks(node) -> Iterator[dict]:
+    """Yield every dict in *node* with ``type == 'image'`` and a base64 source.
+
+    Walks lists and dicts recursively so images nested inside
+    ``tool_result.content[...]`` are found.
+    """
+    if isinstance(node, dict):
+        if (
+            node.get("type") == "image"
+            and isinstance(node.get("source"), dict)
+            and node["source"].get("type") == "base64"
+        ):
+            yield node
+        for v in node.values():
+            yield from _iter_image_blocks(v)
+    elif isinstance(node, list):
+        for v in node:
+            yield from _iter_image_blocks(v)
+
+
+def _is_placeholder_text_block(block: dict) -> bool:
+    """True if *block* is a text block emitted by a prior scrub run."""
+    if block.get("type") != "text":
+        return False
+    text = block.get("text", "")
+    return isinstance(text, str) and text.startswith(PLACEHOLDER_PREFIX)
+
+
+def _make_placeholder(width: int | None, height: int | None, byte_size: int,
+                      reason: str, max_dim_px: int, max_bytes: int) -> dict:
+    """Build the replacement text block for an oversized image."""
+    if width and height:
+        dims = f"{width}x{height}"
+    else:
+        dims = "unknown dimensions"
+    text = (
+        f"{PLACEHOLDER_PREFIX} {dims} ({byte_size:,} bytes) "
+        f"exceeded limits (dim>{max_dim_px}px or bytes>{max_bytes:,}, "
+        f"reason={reason})]"
+    )
+    return {"type": "text", "text": text}
+
+
+def _scrub_image_block(block: dict, finding: ImageFinding, max_dim_px: int,
+                       max_bytes: int) -> None:
+    """Replace *block*'s image source/data with a placeholder text.
+
+    Mutates the block in place: changes ``type`` to ``text``, removes
+    ``source``, adds ``text``.
+    """
+    placeholder = _make_placeholder(
+        finding.width, finding.height, finding.byte_size,
+        finding.reason, max_dim_px, max_bytes,
+    )
+    block.clear()
+    block.update(placeholder)
+
+
+def _scan_and_patch_line(line: str, session_path: Path, line_number: int,
+                        max_dim_px: int, max_bytes: int,
+                        report: ScrubReport) -> tuple[str, bool]:
+    """Process one jsonl line. Returns (new_line, modified)."""
+    try:
+        obj = json.loads(line)
+    except json.JSONDecodeError as exc:
+        report.parse_errors.append((session_path, line_number, str(exc)))
+        return line, False
+
+    modified = False
+    timestamp = obj.get("timestamp", "") if isinstance(obj, dict) else ""
+
+    # Check existing placeholders for idempotency. Walk the same tree
+    # the image walker would.
+    if isinstance(obj, dict):
+        for placeholder in _iter_placeholder_blocks(obj):
+            report.skipped_already_scrubbed += 1
+
+    for block in list(_iter_image_blocks(obj)):
+        report.images_scanned += 1
+        src = block.get("source", {})
+        b64 = src.get("data", "")
+        if not isinstance(b64, str) or not b64:
+            continue
+        # Cheap byte-size estimate before decode: base64 is 4/3 the
+        # binary size, so binary ≈ len(b64) * 3 / 4.
+        approx_bytes = (len(b64) * 3) // 4
+        try:
+            raw = base64.b64decode(b64, validate=False)
+        except (binascii.Error, ValueError):
+            continue
+        byte_size = len(raw)
+        dims = image_dimensions(raw)
+        width, height = (dims if dims is not None else (None, None))
+
+        over_dim = bool(dims and (width > max_dim_px or height > max_dim_px))
+        over_bytes = byte_size > max_bytes
+        if not (over_dim or over_bytes):
+            continue
+
+        reason = (
+            "both" if over_dim and over_bytes
+            else ("dimension" if over_dim else "byte_size")
+        )
+        finding = ImageFinding(
+            session_path=session_path,
+            line_number=line_number,
+            width=width,
+            height=height,
+            byte_size=byte_size,
+            reason=reason,
+            timestamp=timestamp,
+        )
+        report.findings.append(finding)
+        _scrub_image_block(block, finding, max_dim_px, max_bytes)
+        report.images_scrubbed += 1
+        modified = True
+
+    # Also blank toolUseResult.file.base64 if it's huge — Claude Code
+    # metadata, doesn't affect the API conversation but bloats the file.
+    if isinstance(obj, dict):
+        tur = obj.get("toolUseResult")
+        if isinstance(tur, dict):
+            f = tur.get("file")
+            if isinstance(f, dict) and isinstance(f.get("base64"), str):
+                if len(f["base64"]) > 1024 and modified:
+                    f["base64"] = "[removed by claude-recall scrub-images]"
+
+    if not modified:
+        return line, False
+    return json.dumps(obj, ensure_ascii=False) + "\n", True
+
+
+def _iter_placeholder_blocks(node) -> Iterator[dict]:
+    """Yield blocks that look like prior-run placeholders."""
+    if isinstance(node, dict):
+        if _is_placeholder_text_block(node):
+            yield node
+        for v in node.values():
+            yield from _iter_placeholder_blocks(v)
+    elif isinstance(node, list):
+        for v in node:
+            yield from _iter_placeholder_blocks(v)
+
+
+def scrub_session(session_path: Path, *, max_dim_px: int = DEFAULT_MAX_DIM_PX,
+                  max_bytes: int = DEFAULT_MAX_BYTES, dry_run: bool = False,
+                  backup: bool = True, report: ScrubReport | None = None,
+                  ) -> ScrubReport:
+    """Scrub oversized images out of one session jsonl.
+
+    If *dry_run* is True, no file changes are made; the report still
+    lists every finding the scrub *would* make.
+    """
+    if report is None:
+        report = ScrubReport()
+    report.sessions_scanned += 1
+
+    if not session_path.is_file():
+        return report
+
+    tmp_path = session_path.with_suffix(session_path.suffix + ".scrub.tmp")
+    bak_path: Path | None = None
+    line_modified_count = 0
+
+    with open(session_path, "r", encoding="utf-8") as r, \
+         open(tmp_path, "w", encoding="utf-8", newline="") as w:
+        for lineno, raw_line in enumerate(r, start=1):
+            new_line, modified = _scan_and_patch_line(
+                raw_line, session_path, lineno, max_dim_px, max_bytes, report,
+            )
+            if modified:
+                line_modified_count += 1
+            w.write(new_line)
+
+    if line_modified_count == 0 or dry_run:
+        # Nothing to write; clean up the temp file.
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        return report
+
+    if backup:
+        ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        bak_path = session_path.with_suffix(session_path.suffix + f".bak.{ts}")
+        shutil.copy2(session_path, bak_path)
+
+    os.replace(tmp_path, session_path)
+    report.sessions_modified += 1
+    return report
+
+
+def iter_session_files(archive_root: Path, project_slug: str | None = None,
+                       session_id_prefix: str | None = None) -> Iterator[Path]:
+    """Yield session jsonl paths in scope.
+
+    - With *project_slug*: walk only that project's archive directory.
+    - Without: walk every project directory under *archive_root*.
+    - With *session_id_prefix*: filter to files whose stem starts with
+      the prefix. Useful for the ``--session abc12345`` form.
+    """
+    if not archive_root.is_dir():
+        return
+    if project_slug:
+        roots = [archive_root / project_slug]
+    else:
+        roots = [p for p in archive_root.iterdir() if p.is_dir()]
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("*.jsonl")):
+            if session_id_prefix and not path.stem.startswith(session_id_prefix):
+                continue
+            yield path
+
+
+def run_scrub(archive_root: Path, *, project_slug: str | None = None,
+              session_id_prefix: str | None = None,
+              max_dim_px: int = DEFAULT_MAX_DIM_PX,
+              max_bytes: int = DEFAULT_MAX_BYTES,
+              dry_run: bool = False, backup: bool = True,
+              ) -> ScrubReport:
+    """Top-level entry: scrub every session jsonl in scope."""
+    report = ScrubReport()
+    for session_path in iter_session_files(
+        archive_root, project_slug=project_slug,
+        session_id_prefix=session_id_prefix,
+    ):
+        scrub_session(
+            session_path,
+            max_dim_px=max_dim_px,
+            max_bytes=max_bytes,
+            dry_run=dry_run,
+            backup=backup,
+            report=report,
+        )
+    return report
+
+
+def format_report(report: ScrubReport, dry_run: bool = False) -> str:
+    """Human-readable summary."""
+    lines: list[str] = []
+    if dry_run:
+        lines.append("[DRY RUN] no files modified")
+    lines.append(
+        f"sessions: {report.sessions_scanned} scanned, "
+        f"{report.sessions_modified} modified"
+    )
+    lines.append(
+        f"images:   {report.images_scanned} scanned, "
+        f"{report.images_scrubbed} scrubbed, "
+        f"{report.skipped_already_scrubbed} already-scrubbed"
+    )
+    if report.findings:
+        lines.append("")
+        lines.append("findings:")
+        for f in report.findings:
+            dims = f"{f.width}x{f.height}" if f.width and f.height else "?x?"
+            lines.append(
+                f"  {f.session_path.name}:{f.line_number} "
+                f"{dims} ({f.byte_size:,} bytes, reason={f.reason})"
+            )
+    if report.parse_errors:
+        lines.append("")
+        lines.append("parse errors (skipped lines):")
+        for path, lineno, exc in report.parse_errors[:5]:
+            lines.append(f"  {path.name}:{lineno} {exc}")
+        if len(report.parse_errors) > 5:
+            lines.append(f"  ... and {len(report.parse_errors) - 5} more")
+    return "\n".join(lines)

--- a/tests/test_scrub_images.py
+++ b/tests/test_scrub_images.py
@@ -1,0 +1,288 @@
+"""Tests for the scrub-images subcommand (v0.10.0)."""
+
+from __future__ import annotations
+
+import base64
+import json
+import struct
+import zlib
+from pathlib import Path
+
+import pytest
+
+from claude_recall import scrub_images
+
+
+# --- Synthetic image fixtures -------------------------------------------------
+
+def _png(width: int, height: int) -> bytes:
+    """Build a minimal valid PNG of the requested dimensions.
+
+    The image data is a single all-white scanline (we never decode it
+    in scrub-images — only the IHDR is read). Crafted by hand rather
+    than depending on Pillow.
+    """
+    signature = b"\x89PNG\r\n\x1a\n"
+
+    def chunk(tag: bytes, payload: bytes) -> bytes:
+        crc = zlib.crc32(tag + payload).to_bytes(4, "big")
+        return len(payload).to_bytes(4, "big") + tag + payload + crc
+
+    ihdr_payload = (
+        width.to_bytes(4, "big")
+        + height.to_bytes(4, "big")
+        + b"\x08\x06\x00\x00\x00"  # bit-depth=8, color=RGBA, no filter/interlace
+    )
+    raw = b"".join(
+        b"\x00" + b"\xff" * (4 * width) for _ in range(height)
+    )
+    idat_payload = zlib.compress(raw)
+    return (
+        signature
+        + chunk(b"IHDR", ihdr_payload)
+        + chunk(b"IDAT", idat_payload)
+        + chunk(b"IEND", b"")
+    )
+
+
+def _jpeg(width: int, height: int) -> bytes:
+    """Minimal JPEG-like blob with a synthetic SOF0 marker.
+
+    Real JPEGs are encoded; we only need the SOF dimensions to be
+    parseable, so we emit SOI, SOF0 with the requested dimensions,
+    and EOI. The scrub-images parser does not validate the rest.
+    """
+    soi = b"\xff\xd8"
+    eoi = b"\xff\xd9"
+    sof_len = 8 + 3  # 2 length + 1 precision + 2 height + 2 width + 3 component
+    sof0_payload = (
+        struct.pack(">H", sof_len)
+        + b"\x08"
+        + struct.pack(">H", height)
+        + struct.pack(">H", width)
+        + b"\x01\x11\x00"  # one component, sampling=0x11, qt=0
+    )
+    return soi + b"\xff\xc0" + sof0_payload + eoi
+
+
+# --- Dimension parser tests ---------------------------------------------------
+
+
+def test_png_dimensions_returns_width_height():
+    data = _png(640, 480)
+    assert scrub_images.png_dimensions(data) == (640, 480)
+
+
+def test_png_dimensions_rejects_non_png():
+    assert scrub_images.png_dimensions(b"not a png at all") is None
+
+
+def test_png_dimensions_handles_truncated_input():
+    assert scrub_images.png_dimensions(b"\x89PNG\r\n\x1a\n") is None
+
+
+def test_jpeg_dimensions_returns_width_height():
+    data = _jpeg(800, 600)
+    assert scrub_images.jpeg_dimensions(data) == (800, 600)
+
+
+def test_jpeg_dimensions_rejects_non_jpeg():
+    assert scrub_images.jpeg_dimensions(b"\x89PNG\r\n\x1a\nfake") is None
+
+
+def test_image_dimensions_dispatches_to_png():
+    assert scrub_images.image_dimensions(_png(100, 200)) == (100, 200)
+
+
+def test_image_dimensions_dispatches_to_jpeg():
+    assert scrub_images.image_dimensions(_jpeg(300, 400)) == (300, 400)
+
+
+def test_image_dimensions_returns_none_for_other_formats():
+    assert scrub_images.image_dimensions(b"GIF87a" + b"\x00" * 20) is None
+
+
+# --- Jsonl scrub tests --------------------------------------------------------
+
+def _image_block(data: bytes, media_type: str = "image/png") -> dict:
+    return {
+        "type": "image",
+        "source": {
+            "type": "base64",
+            "data": base64.b64encode(data).decode("ascii"),
+            "media_type": media_type,
+        },
+    }
+
+
+def _tool_result_turn(tool_use_id: str, image_block: dict, ts: str = "2026-06-11T19:00:00Z") -> dict:
+    """Mirror the real jsonl shape: tool_result nested inside user message content."""
+    return {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [{
+                "tool_use_id": tool_use_id,
+                "type": "tool_result",
+                "content": [image_block],
+            }],
+        },
+        "timestamp": ts,
+    }
+
+
+def _write_session(path: Path, lines: list[dict]) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        for obj in lines:
+            f.write(json.dumps(obj) + "\n")
+
+
+def test_scrub_session_finds_and_replaces_oversized_png(tmp_path):
+    session_path = tmp_path / "test-session.jsonl"
+    small = _tool_result_turn("toolu_01", _image_block(_png(640, 480)))
+    big = _tool_result_turn("toolu_02", _image_block(_png(2048, 2048)))
+    _write_session(session_path, [small, big])
+
+    report = scrub_images.scrub_session(session_path, backup=False)
+
+    assert report.sessions_modified == 1
+    assert report.images_scanned == 2
+    assert report.images_scrubbed == 1
+    assert len(report.findings) == 1
+    finding = report.findings[0]
+    assert finding.width == 2048 and finding.height == 2048
+    assert finding.reason == "dimension"
+
+    # Verify the file: small image untouched, big one replaced with text.
+    with open(session_path, encoding="utf-8") as f:
+        rebuilt = [json.loads(line) for line in f]
+    assert rebuilt[0]["message"]["content"][0]["content"][0]["type"] == "image"
+    replaced = rebuilt[1]["message"]["content"][0]["content"][0]
+    assert replaced["type"] == "text"
+    assert scrub_images.PLACEHOLDER_PREFIX in replaced["text"]
+    assert "2048x2048" in replaced["text"]
+
+
+def test_scrub_session_is_idempotent(tmp_path):
+    session_path = tmp_path / "idempotent.jsonl"
+    big = _tool_result_turn("toolu_03", _image_block(_png(3000, 1500)))
+    _write_session(session_path, [big])
+
+    first = scrub_images.scrub_session(session_path, backup=False)
+    assert first.images_scrubbed == 1
+
+    second = scrub_images.scrub_session(session_path, backup=False)
+    assert second.images_scrubbed == 0
+    assert second.skipped_already_scrubbed >= 1
+
+
+def test_scrub_session_preserves_tool_use_id(tmp_path):
+    session_path = tmp_path / "linkage.jsonl"
+    turn = _tool_result_turn("toolu_keep_this", _image_block(_png(4096, 2048)))
+    _write_session(session_path, [turn])
+
+    scrub_images.scrub_session(session_path, backup=False)
+
+    with open(session_path, encoding="utf-8") as f:
+        obj = json.loads(f.readline())
+    result_block = obj["message"]["content"][0]
+    assert result_block["tool_use_id"] == "toolu_keep_this"
+    assert result_block["type"] == "tool_result"
+
+
+def test_scrub_session_dry_run_does_not_modify_file(tmp_path):
+    session_path = tmp_path / "dryrun.jsonl"
+    big = _tool_result_turn("toolu_04", _image_block(_png(3000, 3000)))
+    _write_session(session_path, [big])
+    before = session_path.read_bytes()
+
+    report = scrub_images.scrub_session(session_path, dry_run=True, backup=False)
+
+    assert report.images_scrubbed == 1
+    assert len(report.findings) == 1
+    after = session_path.read_bytes()
+    assert before == after
+
+
+def test_scrub_session_writes_backup_by_default(tmp_path):
+    session_path = tmp_path / "backup.jsonl"
+    big = _tool_result_turn("toolu_05", _image_block(_png(2048, 2048)))
+    _write_session(session_path, [big])
+
+    scrub_images.scrub_session(session_path, backup=True)
+
+    backups = list(tmp_path.glob("backup.jsonl.bak.*"))
+    assert len(backups) == 1
+    # The backup should contain the original image bytes.
+    bak_text = backups[0].read_text(encoding="utf-8")
+    assert '"type": "image"' in bak_text
+
+
+def test_scrub_session_no_backup_when_no_changes(tmp_path):
+    session_path = tmp_path / "no-change.jsonl"
+    small = _tool_result_turn("toolu_06", _image_block(_png(800, 600)))
+    _write_session(session_path, [small])
+
+    scrub_images.scrub_session(session_path, backup=True)
+
+    assert list(tmp_path.glob("no-change.jsonl.bak.*")) == []
+
+
+def test_scrub_session_byte_size_threshold(tmp_path):
+    """An image small in dimensions but large in bytes should be caught."""
+    session_path = tmp_path / "bytes.jsonl"
+    big_bytes_small_dim = _tool_result_turn(
+        "toolu_07", _image_block(_png(500, 500)),
+    )
+    _write_session(session_path, [big_bytes_small_dim])
+
+    # Set a max_bytes lower than the encoded PNG to trigger byte-size catch.
+    report = scrub_images.scrub_session(
+        session_path, max_bytes=100, backup=False,
+    )
+
+    assert report.images_scrubbed == 1
+    assert report.findings[0].reason in {"byte_size", "both"}
+
+
+def test_iter_session_files_filters_by_session_prefix(tmp_path):
+    archive_root = tmp_path / "archive"
+    proj = archive_root / "proj-slug"
+    proj.mkdir(parents=True)
+    (proj / "abc12345-deadbeef.jsonl").write_text("{}", encoding="utf-8")
+    (proj / "def67890-cafebabe.jsonl").write_text("{}", encoding="utf-8")
+
+    found = list(scrub_images.iter_session_files(
+        archive_root, project_slug="proj-slug",
+        session_id_prefix="abc12345",
+    ))
+    assert len(found) == 1
+    assert found[0].stem.startswith("abc12345")
+
+
+def test_run_scrub_walks_all_projects_when_slug_none(tmp_path):
+    archive_root = tmp_path / "archive"
+    for slug in ["proj-a", "proj-b"]:
+        d = archive_root / slug
+        d.mkdir(parents=True)
+        path = d / f"{slug}-session.jsonl"
+        _write_session(path, [
+            _tool_result_turn(f"toolu_{slug}", _image_block(_png(2500, 2500))),
+        ])
+
+    report = scrub_images.run_scrub(archive_root, project_slug=None, backup=False)
+    assert report.sessions_scanned == 2
+    assert report.images_scrubbed == 2
+
+
+def test_format_report_renders_findings(tmp_path):
+    session_path = tmp_path / "fmt.jsonl"
+    big = _tool_result_turn("toolu_fmt", _image_block(_png(2200, 2200)))
+    _write_session(session_path, [big])
+
+    report = scrub_images.scrub_session(session_path, dry_run=True, backup=False)
+    output = scrub_images.format_report(report, dry_run=True)
+
+    assert "DRY RUN" in output
+    assert "2200x2200" in output
+    assert "fmt.jsonl" in output


### PR DESCRIPTION
## Summary

Adds `claude-recall scrub-images` to recover Claude Code sessions wedged by the Anthropic many-image dimension limit (2000px on any axis). Walks session jsonls, finds image content blocks exceeding the threshold, and replaces each one with a text placeholder that preserves the surrounding `tool_use_id` linkage so resume just works.

Operationally validated on a real session that hit the limit on 2026-06-11 (PhysicianAssistant — two 2048×2048 JPEGs in `tool_result` blocks). The manual surgical fix that unblocked it is the reference implementation for this command.

## What it does

- **Module** `src/claude_recall/scrub_images.py` (340 lines)
  - PNG dimension parser (IHDR chunk, bytes 16–24)
  - JPEG dimension parser (SOFn marker walker, excludes DHT/DAC/DNL)
  - Recursive image walker — handles nesting inside `tool_result` blocks (the common case)
  - Atomic writes via temp file + `os.replace`
  - Idempotent: canonical placeholder is detected on re-runs and skipped
  - Structured `ScrubReport` for callers (sessions/images scanned, findings, parse errors)
- **CLI** `scrub-images` subcommand:
  - `--project <slug>` (default: cwd-derived slug; `all` for every project)
  - `--session <prefix>` for UUID-prefix scope
  - `--max-dim 2000` (Anthropic many-image limit, June 2026)
  - `--max-bytes 5242880` (5 MiB byte-size safety net)
  - `--dry-run` to preview, `--no-backup` to skip sidecar
- **Safety**: `.bak.<timestamp>` sidecar before any modification by default. Writes are atomic. Idempotent.

## Usage

```bash
# Default: scope to whichever project you're cd'd into.
claude-recall scrub-images

# Cover everything:
claude-recall scrub-images --project all --dry-run    # preview
claude-recall scrub-images --project all              # execute

# Surgical scope:
claude-recall scrub-images --project e--dev-work-PhysicianAssistant --session 69811251
```

## What it does NOT do

- Does not re-index after scrub. The DB indexer tolerates jsonl edits — re-run `claude-recall index` if you want the scrubbed state reflected in search.
- Does not delete entire turns. Substitution preserves conversation structure, which is safer for resume.
- Other image formats (GIF, WebP) aren't dimension-parsed yet; they fall through to the `--max-bytes` threshold.

## Test plan

- [x] 18 new unit tests covering PNG/JPEG parsers, scrub semantics, idempotency, dry-run, backup, byte-size threshold, multi-project walks, report formatting
- [x] Full suite: 303 pass / 1 skip, 0 regressions
- [x] CLI smoke test: `--help`, dry-run against a real project archive (3 sessions, 93 images, 0 currently oversized — matches manually-scrubbed state)
- [ ] Operational validation in the wild (the original PA session was unblocked by the manual procedure that became this implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)