### PR TITLE
feat(v0.11.0): claude-recall orphan-slugs to detect pre-migration data-loss risk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,104 @@
 
 All notable changes to `claude-recall`. Format: one section per tag.
 
+## v0.11.0 — 2026-06-12
+
+`claude-recall orphan-slugs` — detect claude-recall slug archives whose
+source project path no longer exists, and flag pre-migration slugs
+that have a live successor so the history can be merged with
+`claude-recall migrate` before it's stranded.
+
+### Background
+
+The motivating incident: on 2026-06-11 OC discovered that
+strictlyelvisshow's Claude Code resume picker was empty — the project
+had been actively used since March, but the May 26 bulk-migration
+script had a gap and never moved its slug archive forward. The sessions
+sat in `~/.claude/projects/e--Documents-Work-strictlyelvisshow/` while
+all new sessions landed under `e--dev-work-strictlyelvisshow/`. The
+following day's disk cleanup deleted the May 26 migration backup —
+the only remaining copy. The sessions were recovered from Backblaze
+the same afternoon, but the failure mode was preventable: an
+"orphan slug with a live successor" is exactly the shape a periodic
+sanity-check should catch before any backup gets cleaned.
+
+`claude-recall orphan-slugs` is that sanity-check.
+
+### What it catches
+
+Three categories of finding, with severity reflected in the exit code:
+
+- **`pre_migration_slug` (ERROR, exit 2)** — an orphan slug whose
+  source path uses a pre-migration prefix (default: contains
+  `Documents`) AND a live slug exists that looks like the
+  post-migration successor (matched by trailing project-name
+  segment). These are the actionable case: print the exact
+  `claude-recall migrate --from X --to Y` command needed to merge
+  the history into the live slug.
+- **`orphan_slug` (WARN, exit 1)** — a filesystem slug whose
+  inferred source path doesn't exist and no obvious successor is
+  apparent. Sessions are intact but unreachable from any current
+  project location. Decision left to the user (keep for history,
+  delete, or manually migrate to a successor they know).
+- **`missing_slug` (OK, exit 0)** — an expected project path with
+  no archive directory yet. Informational only — Claude Code
+  creates the slug directory on first session.
+
+### Usage
+
+```bash
+# Auto-detect Project Manager projects.json on Windows.
+claude-recall orphan-slugs
+
+# Declare project roots explicitly (e.g., 'e:/dev/work').
+claude-recall orphan-slugs \
+  --projects-root e:/dev/work \
+  --projects-root e:/dev/personal \
+  --projects-root e:/dev/school
+
+# Point at an explicit projects.json file.
+claude-recall orphan-slugs --projects-json /path/to/projects.json
+
+# Mix individual paths with roots.
+claude-recall orphan-slugs --path e:/dev/work/CrewTrack --path e:/dev/personal/Manuscript-FULL
+
+# Customize the "pre-migration marker" if your slug history uses a
+# different path-segment convention.
+claude-recall orphan-slugs --old-style-marker MyOldRoot
+```
+
+### Detection details
+
+- **Reverse-slug parsing** is best-effort: the slug format collapses
+  `:`, `\`, and `/` all to `-`, so reverse is lossy when path
+  segments contain dashes literally (e.g., `kevin-laptop-case`).
+  The detector still flags these correctly when paired with an
+  expected-paths input that includes the live path.
+- **Pre-migration marker** defaults to `Documents` (matching the
+  pre-May-26 path convention in the SES incident). Configurable
+  via `--old-style-marker` (repeatable).
+- **Successor matching** uses the last path segment as the anchor:
+  e.g. `e--Documents-Work-strictlyelvisshow` matches any live slug
+  ending in `-strictlyelvisshow`. Successor candidates include both
+  filesystem slugs and slugs derived from expected paths (so a
+  pre-migration slug can match a yet-to-be-created successor).
+- **Expected-paths inputs** are taken from three places, all
+  optional: `--projects-json`, `--path`, `--projects-root`. Without
+  any input, the command runs in filesystem-only mode (every slug
+  must reverse-resolve to an existing path; otherwise it's
+  flagged).
+
+### What it doesn't do
+
+- Doesn't auto-migrate. The recommended `claude-recall migrate`
+  command is printed; the user runs it. Auto-migration could merge
+  the wrong history if the successor heuristic is wrong.
+- Doesn't detect orphans whose source path uses an unusual encoding
+  Claude Code applies but `slug_from_path` doesn't (e.g., the dot
+  collapse in `SkullUp\com.efun.euklqb` may produce a slug that
+  this tool can't reverse cleanly). Workaround: pass the live path
+  via `--path` so it's matched directly.
+
 ## v0.10.0 — 2026-06-11
 
 `claude-recall scrub-images` — replace oversized image content blocks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-recall"
-version = "0.10.0"
+version = "0.11.0"
 description = "Automatic, cheap, precise query of Claude Code session archives via SQLite FTS5 + hooks."
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/claude_recall/__init__.py
+++ b/src/claude_recall/__init__.py
@@ -3,6 +3,6 @@
 See docs/PLAN.md for the implementation plan.
 """
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 __author__ = "Mark McArthey"
 __license__ = "MIT"

--- a/src/claude_recall/cli.py
+++ b/src/claude_recall/cli.py
@@ -297,6 +297,45 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    # orphan-slugs (v0.11.0)
+    p_orphan = sub.add_parser(
+        "orphan-slugs",
+        help=(
+            "Detect claude-recall slug archives whose source project path "
+            "is missing (potential data-loss risk if a backup gets cleaned)."
+        ),
+    )
+    p_orphan.add_argument(
+        "--projects-json",
+        help=(
+            "Path to a VSCode Project Manager projects.json file. "
+            "Auto-detects %%APPDATA%%/Code/User/globalStorage/"
+            "alefragnani.project-manager/projects.json if present."
+        ),
+    )
+    p_orphan.add_argument(
+        "--path", action="append", default=[], metavar="PATH",
+        help="Expected project path (repeatable). Use to declare projects not in projects.json.",
+    )
+    p_orphan.add_argument(
+        "--projects-root", action="append", default=[], metavar="ROOT",
+        help=(
+            "Directory whose immediate children are projects (repeatable). "
+            "Useful when you don't use Project Manager (e.g., 'e:/dev/work')."
+        ),
+    )
+    p_orphan.add_argument(
+        "--no-auto-projects-json", action="store_true",
+        help="Skip the auto-detected Project Manager projects.json even if present.",
+    )
+    p_orphan.add_argument(
+        "--old-style-marker", action="append", default=None, metavar="MARKER",
+        help=(
+            "Path-segment name that marks a pre-migration slug (repeatable). "
+            "Default: 'Documents'. Override to customize for other migration shapes."
+        ),
+    )
+
     # scrub-images (v0.10.0)
     p_scrub = sub.add_parser(
         "scrub-images",
@@ -398,6 +437,7 @@ def main(argv: list[str] | None = None) -> int:
         "emit-prompt-context": _cmd_emit_prompt_context,
         "doctor": _cmd_doctor,
         "scrub-images": _cmd_scrub_images,
+        "orphan-slugs": _cmd_orphan_slugs,
     }
     return handlers[args.command](args, cfg)
 
@@ -817,6 +857,39 @@ def _cmd_scrub_images(args: argparse.Namespace, cfg: Config) -> int:
         backup=not args.no_backup,
     )
     print(_scrub.format_report(report, dry_run=args.dry_run))
+    return 0
+
+
+# --- orphan-slugs -----------------------------------------------------------
+
+def _cmd_orphan_slugs(args: argparse.Namespace, cfg: Config) -> int:
+    """Detect orphan/missing slug archives. Exit code reflects severity."""
+    from . import orphan_slugs as _orphan
+
+    projects_json: Path | None
+    if args.projects_json:
+        projects_json = Path(args.projects_json).expanduser()
+    elif args.no_auto_projects_json:
+        projects_json = None
+    else:
+        projects_json = _orphan.default_projects_json_path()
+
+    explicit = [Path(p).expanduser() for p in args.path]
+    roots = [Path(p).expanduser() for p in args.projects_root]
+    markers = args.old_style_marker or _orphan.DEFAULT_OLD_STYLE_MARKERS
+
+    report = _orphan.run_orphan_check(
+        cfg.archive_root,
+        projects_json=projects_json,
+        explicit_paths=explicit,
+        projects_roots=roots,
+        old_style_markers=markers,
+    )
+    print(_orphan.format_report(report))
+    if report.has_errors:
+        return 2
+    if report.has_warnings:
+        return 1
     return 0
 
 

--- a/src/claude_recall/orphan_slugs.py
+++ b/src/claude_recall/orphan_slugs.py
@@ -1,0 +1,442 @@
+"""Detect orphan/missing claude-recall slug archives (v0.11.0).
+
+This module catches the failure mode that produced the strictlyelvisshow
+data-loss incident on 2026-06-11:
+
+1. A bulk-migration script (in that case, `repo_migrate.ps1` from May 26)
+   moves project directories but misses some of the corresponding
+   ``claude-recall`` slug archives.
+2. The old-style slug (e.g. ``e--Documents-Work-strictlyelvisshow``)
+   keeps the sessions but is no longer reached by Claude Code, because
+   sessions opened from the new project path land under a new slug
+   (e.g. ``e--dev-work-strictlyelvisshow``) which has no inherited
+   history.
+3. The next person to run a disk cleanup deletes the May-26 migration
+   backup (the only remaining copy) without realizing it. The sessions
+   are then unrecoverable from anywhere but cloud backup.
+
+`claude-recall orphan-slugs` surfaces three categories of finding:
+
+- **Orphan slug** — a directory under ``~/.claude/projects/`` whose
+  inferred source path no longer exists on disk and which is not
+  claimed by any expected-paths input. The archive is intact but
+  unreachable by any active Claude Code session.
+- **Pre-migration slug with a live successor** — an orphan slug whose
+  path uses an old-style prefix (e.g. ``e--Documents-…``) that maps
+  to a live new-style slug at a current location. These need
+  ``claude-recall migrate --from <old> --to <new>`` to merge the
+  sessions into the active slug. This is the specific shape that
+  produced the SES incident.
+- **Missing slug** — a project path supplied as expected that has no
+  corresponding archive directory. Informational only — Claude Code
+  creates the slug directory on first session in that project.
+
+Inputs:
+
+- ``--projects-json <path>`` to point at a Project Manager
+  ``projects.json`` (or any JSON file with a list of
+  ``{ rootPath: "..." }`` objects). On Windows, this is auto-detected
+  at ``%APPDATA%/Code/User/globalStorage/alefragnani.project-manager/projects.json``.
+- ``--path <p>`` (repeatable) to add expected project paths from the
+  command line.
+- ``--projects-roots <p>`` (repeatable) to declare directory roots
+  whose immediate children are projects (e.g. ``e:/dev/work``,
+  ``e:/dev/personal``). Useful when you don't use Project Manager.
+
+If no inputs are given, the command runs with **filesystem-only mode**:
+every slug archive is reverse-resolved to a path; if the path doesn't
+exist the slug is flagged as an orphan. This catches the common case
+without requiring any setup.
+
+Exit codes:
+
+- 0 — clean (no orphans, no recommended migrations)
+- 1 — warnings only (orphan slugs that don't need a migration)
+- 2 — actionable findings (pre-migration slug with a live successor)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Iterator
+
+from .projects import slug_from_path
+
+# Source-path prefixes that mark "pre-migration" slugs in this codebase.
+# Customisable via OrphanSlugConfig.old_style_path_markers if needed
+# (Mark's project tree uses ``e:\Documents\…`` for pre-May-26 paths).
+DEFAULT_OLD_STYLE_MARKERS = ("Documents",)
+
+# Auto-detected location of VSCode Project Manager's project list.
+DEFAULT_PROJECTS_JSON_RELATIVE = (
+    "Code/User/globalStorage/alefragnani.project-manager/projects.json"
+)
+
+
+@dataclass
+class OrphanFinding:
+    """One finding from an orphan-slug scan."""
+
+    kind: str            # "orphan_slug" | "pre_migration_slug" | "missing_slug"
+    severity: str        # "OK" | "WARN" | "ERROR"
+    slug: str            # the filesystem slug (or expected slug for missing)
+    inferred_path: Path | None = None
+    suggested_target_slug: str | None = None
+    suggested_action: str = ""
+    detail: str = ""
+
+
+@dataclass
+class OrphanReport:
+    """Outcome of one orphan-slug scan."""
+
+    archive_root: Path
+    findings: list[OrphanFinding] = field(default_factory=list)
+    slugs_scanned: int = 0
+    expected_paths_count: int = 0
+
+    @property
+    def has_errors(self) -> bool:
+        return any(f.severity == "ERROR" for f in self.findings)
+
+    @property
+    def has_warnings(self) -> bool:
+        return any(f.severity == "WARN" for f in self.findings)
+
+
+def _read_projects_json(path: Path) -> list[Path]:
+    """Extract project root paths from a Project Manager-style projects.json.
+
+    Returns a deduplicated list of Paths. Tolerates missing files and
+    malformed JSON by returning an empty list.
+    """
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(data, list):
+        return []
+    paths: list[Path] = []
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        root = entry.get("rootPath")
+        if isinstance(root, str) and root.strip():
+            # Skip placeholder entries ("Root Path" is the default before
+            # the user edits projects.json the first time).
+            if root.strip().lower() == "root path":
+                continue
+            paths.append(Path(root))
+    # Dedupe while preserving order.
+    seen: set[str] = set()
+    deduped: list[Path] = []
+    for p in paths:
+        key = str(p).lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(p)
+    return deduped
+
+
+def _enumerate_project_root_children(root: Path) -> Iterator[Path]:
+    """Yield immediate child directories of *root* that look like projects.
+
+    Filters out hidden directories (starting with ``.``) and known
+    non-project conventions (``__pycache__``, ``node_modules``). Does
+    not recurse — the caller passes each tier explicitly (e.g.
+    ``e:/dev/work``, ``e:/dev/personal``).
+    """
+    if not root.is_dir():
+        return
+    for child in root.iterdir():
+        if not child.is_dir():
+            continue
+        if child.name.startswith("."):
+            continue
+        if child.name in {"__pycache__", "node_modules", "obj", "bin"}:
+            continue
+        yield child
+
+
+def _gather_expected_paths(
+    *, projects_json: Path | None,
+    explicit_paths: Iterable[Path],
+    projects_roots: Iterable[Path],
+) -> list[Path]:
+    """Collect expected project paths from all input sources."""
+    paths: list[Path] = []
+    if projects_json is not None:
+        paths.extend(_read_projects_json(projects_json))
+    paths.extend(explicit_paths)
+    for root in projects_roots:
+        paths.extend(_enumerate_project_root_children(root))
+    # Dedupe.
+    seen: set[str] = set()
+    out: list[Path] = []
+    for p in paths:
+        key = str(p).lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(p)
+    return out
+
+
+def _reverse_slug_to_path(slug: str) -> Path | None:
+    """Best-effort reverse of slug_from_path.
+
+    The slug format replaces ``:``, ``\\`` and ``/`` all with ``-``, so
+    the reverse is ambiguous (we can't tell which ``-`` was originally
+    a separator versus literal). We assume the most-common case: every
+    ``-`` after the drive letter was a separator. On Windows the result
+    looks like ``e:/Documents/Work/strictlyelvisshow``.
+
+    Returns None if the slug is too short to even parse a drive letter.
+    """
+    if len(slug) < 4:
+        return None
+    # Expected shape: ``<drive-letter>--<segments-joined-by-dashes>``
+    # Lower-case drive letter then two literal dashes (one for the
+    # original ``:``, one for the trailing path separator).
+    if slug[1:3] != "--":
+        return None
+    drive = slug[0]
+    if not drive.isalpha():
+        return None
+    rest = slug[3:]
+    if not rest:
+        return None
+    # Translate dashes back to forward slashes; Path will normalise.
+    path_str = f"{drive}:/{rest.replace('-', '/')}"
+    return Path(path_str)
+
+
+def _is_pre_migration_slug(slug: str, markers: Iterable[str]) -> bool:
+    """True if *slug* looks like a pre-migration slug worth flagging.
+
+    Matches when the slug contains any of the configured markers in a
+    case-sensitive segment position. The default marker is
+    ``"Documents"`` (Mark's pre-May-26 path convention).
+    """
+    parts = slug.split("-")
+    return any(marker in parts for marker in markers)
+
+
+def _find_live_successor_slug(
+    pre_slug: str, all_slugs: Iterable[str], markers: Iterable[str],
+) -> str | None:
+    """Heuristic: find a live slug that looks like the post-migration form.
+
+    Strategy: strip the marker segments from *pre_slug* and look for a
+    live slug whose tail (last few segments) matches. E.g.
+    ``e--Documents-Work-strictlyelvisshow`` stripped of ``Documents``
+    and ``Work`` becomes ``e----strictlyelvisshow``; we look for any
+    live slug ending in ``strictlyelvisshow``.
+
+    Returns the first matching live slug, or None if no obvious
+    successor is found.
+    """
+    parts = pre_slug.split("-")
+    tail_parts = [p for p in parts if p and p not in markers]
+    if not tail_parts:
+        return None
+    # The most specific part is the last one — that's typically the
+    # project's own name and the best matching anchor.
+    project_name = tail_parts[-1]
+    for other in all_slugs:
+        if other == pre_slug:
+            continue
+        if other.endswith(f"-{project_name}"):
+            return other
+    return None
+
+
+def _list_filesystem_slugs(archive_root: Path) -> list[str]:
+    """Return the names of every immediate child directory of *archive_root*."""
+    if not archive_root.is_dir():
+        return []
+    return sorted(
+        p.name for p in archive_root.iterdir()
+        if p.is_dir() and not p.name.startswith(".")
+    )
+
+
+def run_orphan_check(
+    archive_root: Path,
+    *,
+    projects_json: Path | None = None,
+    explicit_paths: Iterable[Path] = (),
+    projects_roots: Iterable[Path] = (),
+    old_style_markers: Iterable[str] = DEFAULT_OLD_STYLE_MARKERS,
+) -> OrphanReport:
+    """Scan the archive root for orphan slugs and missing slugs.
+
+    See module docstring for the categorization rules and exit-code
+    semantics.
+    """
+    report = OrphanReport(archive_root=archive_root)
+    filesystem_slugs = _list_filesystem_slugs(archive_root)
+    report.slugs_scanned = len(filesystem_slugs)
+    expected_paths = _gather_expected_paths(
+        projects_json=projects_json,
+        explicit_paths=explicit_paths,
+        projects_roots=projects_roots,
+    )
+    report.expected_paths_count = len(expected_paths)
+    expected_slug_to_path: dict[str, Path] = {
+        slug_from_path(p.resolve() if p.exists() else p): p
+        for p in expected_paths
+    }
+    expected_slugs = set(expected_slug_to_path.keys())
+
+    # Pass 1: orphan slugs (in filesystem, not in expected, source path
+    # doesn't exist).
+    # For successor search we consider BOTH filesystem slugs and expected
+    # slugs — a valid successor may be an expected slug that hasn't
+    # accumulated any sessions yet (no archive dir, but Claude Code
+    # would create it on first use).
+    successor_candidates = list(filesystem_slugs) + list(expected_slugs)
+    for slug in filesystem_slugs:
+        if slug in expected_slugs:
+            continue
+        inferred = _reverse_slug_to_path(slug)
+        if inferred is not None and inferred.exists():
+            # Live slug — not in projects.json but its source path
+            # still exists, so this is just a project the user hasn't
+            # bothered to add to the Project Manager list. Skip.
+            continue
+        # It's orphan-shaped. Check whether it's pre-migration with a
+        # live successor; that's the actionable case.
+        successor = None
+        if _is_pre_migration_slug(slug, old_style_markers):
+            successor = _find_live_successor_slug(
+                slug, successor_candidates, old_style_markers,
+            )
+        if successor is not None:
+            report.findings.append(OrphanFinding(
+                kind="pre_migration_slug",
+                severity="ERROR",
+                slug=slug,
+                inferred_path=inferred,
+                suggested_target_slug=successor,
+                suggested_action=(
+                    f"claude-recall migrate --from {slug} --to {successor}"
+                ),
+                detail=(
+                    "Source path is gone; a live slug appears to be the "
+                    "post-migration successor. Migrate to merge history."
+                ),
+            ))
+        else:
+            report.findings.append(OrphanFinding(
+                kind="orphan_slug",
+                severity="WARN",
+                slug=slug,
+                inferred_path=inferred,
+                suggested_target_slug=None,
+                suggested_action=(
+                    "Project path is gone. If you want to keep the history, "
+                    f"leave the slug in place; if not, `rm -r {archive_root}/{slug}` "
+                    "or run `claude-recall migrate --from {slug} --to <new-slug>` "
+                    "if you know the successor."
+                ),
+                detail=(
+                    "No active project resolves to this slug, and no "
+                    "obvious successor exists in the archive."
+                ),
+            ))
+
+    # Pass 2: missing slugs (expected but no archive directory yet).
+    fs_set = set(filesystem_slugs)
+    for slug, path in expected_slug_to_path.items():
+        if slug in fs_set:
+            continue
+        report.findings.append(OrphanFinding(
+            kind="missing_slug",
+            severity="OK",
+            slug=slug,
+            inferred_path=path,
+            suggested_action=(
+                "No Claude Code session has run in this project yet; "
+                "the slug directory will be created on first session."
+            ),
+        ))
+
+    return report
+
+
+def format_report(report: OrphanReport) -> str:
+    """Human-readable summary of an orphan-slug scan."""
+    lines: list[str] = []
+    lines.append(f"archive root: {report.archive_root}")
+    lines.append(
+        f"slugs scanned: {report.slugs_scanned}, "
+        f"expected paths: {report.expected_paths_count}"
+    )
+
+    errors = [f for f in report.findings if f.severity == "ERROR"]
+    warnings = [f for f in report.findings if f.severity == "WARN"]
+    infos = [f for f in report.findings if f.severity == "OK"]
+
+    if errors:
+        lines.append("")
+        lines.append(
+            f"[ERROR] {len(errors)} pre-migration slug(s) with a live "
+            f"successor — action recommended:"
+        )
+        for f in errors:
+            lines.append(f"  - {f.slug}")
+            lines.append(f"      successor: {f.suggested_target_slug}")
+            lines.append(f"      → {f.suggested_action}")
+
+    if warnings:
+        lines.append("")
+        lines.append(
+            f"[WARN]  {len(warnings)} orphan slug(s) — project path no "
+            f"longer exists:"
+        )
+        for f in warnings:
+            lines.append(f"  - {f.slug}")
+            if f.inferred_path is not None:
+                lines.append(f"      inferred path: {f.inferred_path} (missing)")
+            lines.append(f"      → {f.suggested_action}")
+
+    if infos:
+        lines.append("")
+        lines.append(
+            f"[OK]    {len(infos)} expected project(s) with no archive "
+            f"yet — informational:"
+        )
+        for f in infos[:10]:
+            lines.append(f"  - {f.slug}  ({f.inferred_path})")
+        if len(infos) > 10:
+            lines.append(f"  ... and {len(infos) - 10} more")
+
+    if not report.findings:
+        lines.append("")
+        lines.append("all slugs accounted for — no orphans, no missing.")
+
+    return "\n".join(lines)
+
+
+def default_projects_json_path() -> Path | None:
+    """Return the platform-conventional Project Manager projects.json path.
+
+    On Windows this is ``%APPDATA%/Code/User/globalStorage/.../projects.json``.
+    Returns None if the env-var lookup fails or the path doesn't exist.
+    """
+    appdata = os.environ.get("APPDATA")
+    if not appdata:
+        return None
+    candidate = Path(appdata) / DEFAULT_PROJECTS_JSON_RELATIVE
+    if candidate.exists():
+        return candidate
+    return None

--- a/tests/test_orphan_slugs.py
+++ b/tests/test_orphan_slugs.py
@@ -1,0 +1,277 @@
+"""Tests for the orphan-slugs subcommand (v0.11.0)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from claude_recall import orphan_slugs
+
+
+# --- helpers -----------------------------------------------------------------
+
+
+def _slug_dir(archive_root: Path, slug: str) -> Path:
+    """Create an empty slug directory under *archive_root* and return it."""
+    d = archive_root / slug
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _write_projects_json(path: Path, entries: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(entries, indent=2), encoding="utf-8")
+    return path
+
+
+# --- reverse-slug parser -----------------------------------------------------
+
+
+def test_reverse_slug_handles_typical_windows_shape():
+    p = orphan_slugs._reverse_slug_to_path("e--dev-work-claude-recall")
+    assert p == Path("e:/dev/work/claude/recall")
+
+
+def test_reverse_slug_returns_none_on_too_short():
+    assert orphan_slugs._reverse_slug_to_path("e-") is None
+    assert orphan_slugs._reverse_slug_to_path("") is None
+
+
+def test_reverse_slug_returns_none_when_drive_marker_missing():
+    # Real slugs always have ``--`` after the drive letter; without
+    # that the reverse is ambiguous.
+    assert orphan_slugs._reverse_slug_to_path("nodriveprefix") is None
+
+
+# --- projects.json reading ---------------------------------------------------
+
+
+def test_read_projects_json_extracts_paths(tmp_path):
+    pj = _write_projects_json(tmp_path / "projects.json", [
+        {"name": "A", "rootPath": "E:\\dev\\work\\A", "tags": []},
+        {"name": "B", "rootPath": "E:\\dev\\personal\\B", "tags": []},
+    ])
+    paths = orphan_slugs._read_projects_json(pj)
+    assert len(paths) == 2
+    assert Path("E:\\dev\\work\\A") in paths
+
+
+def test_read_projects_json_dedupes_and_drops_placeholders(tmp_path):
+    pj = _write_projects_json(tmp_path / "projects.json", [
+        {"name": "Project Name", "rootPath": "Root Path"},      # placeholder
+        {"name": "A", "rootPath": "E:\\dev\\work\\A"},
+        {"name": "Dup", "rootPath": "e:\\dev\\work\\a"},        # case-dup
+    ])
+    paths = orphan_slugs._read_projects_json(pj)
+    assert len(paths) == 1
+
+
+def test_read_projects_json_tolerates_malformed_input(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("this is not json", encoding="utf-8")
+    assert orphan_slugs._read_projects_json(bad) == []
+
+
+def test_read_projects_json_returns_empty_for_missing_file(tmp_path):
+    assert orphan_slugs._read_projects_json(tmp_path / "nope.json") == []
+
+
+# --- pre-migration detection -------------------------------------------------
+
+
+def test_is_pre_migration_slug_matches_default_marker():
+    assert orphan_slugs._is_pre_migration_slug(
+        "e--Documents-Work-strictlyelvisshow", ("Documents",)
+    )
+
+
+def test_is_pre_migration_slug_negative_when_marker_absent():
+    assert not orphan_slugs._is_pre_migration_slug(
+        "e--dev-work-strictlyelvisshow", ("Documents",)
+    )
+
+
+def test_find_live_successor_matches_by_project_name_tail():
+    successor = orphan_slugs._find_live_successor_slug(
+        "e--Documents-Work-strictlyelvisshow",
+        all_slugs=[
+            "e--Documents-Work-strictlyelvisshow",
+            "e--dev-work-strictlyelvisshow",
+            "e--dev-work-CrewTrack",
+        ],
+        markers=("Documents",),
+    )
+    assert successor == "e--dev-work-strictlyelvisshow"
+
+
+def test_find_live_successor_returns_none_when_no_match():
+    successor = orphan_slugs._find_live_successor_slug(
+        "e--Documents-old-project",
+        all_slugs=["e--dev-work-CrewTrack", "e--dev-personal-DND"],
+        markers=("Documents",),
+    )
+    assert successor is None
+
+
+# --- end-to-end orphan check -------------------------------------------------
+
+
+def test_run_orphan_check_flags_pre_migration_with_successor(tmp_path):
+    archive = tmp_path / "projects"
+    archive.mkdir()
+
+    # Old-style slug whose source path is gone.
+    _slug_dir(archive, "e--Documents-Work-strictlyelvisshow")
+    # Live successor slug (source path will be created so it doesn't
+    # also flag as orphan).
+    _slug_dir(archive, "e--dev-work-strictlyelvisshow")
+
+    project = tmp_path / "dev" / "work" / "strictlyelvisshow"
+    project.mkdir(parents=True)
+
+    report = orphan_slugs.run_orphan_check(
+        archive,
+        explicit_paths=[project],
+    )
+
+    errors = [f for f in report.findings if f.severity == "ERROR"]
+    assert len(errors) == 1
+    f = errors[0]
+    assert f.kind == "pre_migration_slug"
+    assert f.slug == "e--Documents-Work-strictlyelvisshow"
+    assert f.suggested_target_slug == "e--dev-work-strictlyelvisshow"
+    assert "claude-recall migrate" in f.suggested_action
+
+
+def test_run_orphan_check_finds_successor_from_expected_paths_only(tmp_path):
+    """The Manuscript-FULL case: pre-migration slug has sessions, but the
+    successor slug has no archive yet because Claude Code hasn't run in
+    the new path. The expected path (projects.json) drives the match."""
+    archive = tmp_path / "projects"
+    archive.mkdir()
+    # Old slug has the sessions on disk.
+    _slug_dir(archive, "e--Documents-Hobbies-old-Manuscript-FULL")
+    # New project path exists but no archive dir yet.
+    project = tmp_path / "dev" / "personal" / "Manuscript-FULL"
+    project.mkdir(parents=True)
+
+    report = orphan_slugs.run_orphan_check(
+        archive, explicit_paths=[project],
+    )
+
+    errors = [f for f in report.findings if f.severity == "ERROR"]
+    assert len(errors) == 1
+    assert errors[0].kind == "pre_migration_slug"
+    assert errors[0].suggested_target_slug == orphan_slugs.slug_from_path(project)
+
+
+def test_run_orphan_check_flags_orphan_with_no_successor(tmp_path):
+    archive = tmp_path / "projects"
+    archive.mkdir()
+
+    # A slug whose source path doesn't exist and no successor is present.
+    _slug_dir(archive, "e--dev-personal-deleted-game-project")
+
+    report = orphan_slugs.run_orphan_check(archive)
+
+    warnings = [f for f in report.findings if f.severity == "WARN"]
+    assert len(warnings) == 1
+    assert warnings[0].kind == "orphan_slug"
+
+
+def test_run_orphan_check_does_not_flag_live_slugs(tmp_path):
+    archive = tmp_path / "projects"
+    archive.mkdir()
+    project = tmp_path / "dev" / "work" / "current"
+    project.mkdir(parents=True)
+    # Slug derived from the live path.
+    _slug_dir(archive, orphan_slugs.slug_from_path(project))
+
+    report = orphan_slugs.run_orphan_check(
+        archive,
+        explicit_paths=[project],
+    )
+
+    assert not report.has_errors
+    assert not report.has_warnings
+
+
+def test_run_orphan_check_flags_missing_slug_as_info(tmp_path):
+    archive = tmp_path / "projects"
+    archive.mkdir()
+    project = tmp_path / "dev" / "work" / "noTSession"
+    project.mkdir(parents=True)
+    # Note: no slug directory yet.
+
+    report = orphan_slugs.run_orphan_check(
+        archive,
+        explicit_paths=[project],
+    )
+
+    infos = [f for f in report.findings if f.severity == "OK"]
+    assert len(infos) == 1
+    assert infos[0].kind == "missing_slug"
+
+
+def test_run_orphan_check_projects_json_drives_expectations(tmp_path):
+    archive = tmp_path / "projects"
+    archive.mkdir()
+    project_a = tmp_path / "dev" / "work" / "ProjA"
+    project_a.mkdir(parents=True)
+    pj = _write_projects_json(tmp_path / "projects.json", [
+        {"name": "ProjA", "rootPath": str(project_a)},
+    ])
+
+    # No archive dir for ProjA — should appear as missing_slug.
+    report = orphan_slugs.run_orphan_check(
+        archive, projects_json=pj,
+    )
+    missing = [f for f in report.findings if f.kind == "missing_slug"]
+    assert any(orphan_slugs.slug_from_path(project_a) == f.slug for f in missing)
+
+
+def test_run_orphan_check_projects_root_enumerates_children(tmp_path):
+    archive = tmp_path / "projects"
+    archive.mkdir()
+    work_root = tmp_path / "dev" / "work"
+    (work_root / "Alpha").mkdir(parents=True)
+    (work_root / "Beta").mkdir()
+    (work_root / "__pycache__").mkdir()   # should be filtered out
+    (work_root / ".hidden").mkdir()       # should be filtered out
+
+    report = orphan_slugs.run_orphan_check(
+        archive, projects_roots=[work_root],
+    )
+    assert report.expected_paths_count == 2
+
+
+def test_run_orphan_check_ignores_archive_root_missing():
+    report = orphan_slugs.run_orphan_check(Path("does-not-exist"))
+    assert report.slugs_scanned == 0
+    assert report.findings == []
+
+
+def test_format_report_renders_error_section(tmp_path):
+    archive = tmp_path / "projects"
+    archive.mkdir()
+    _slug_dir(archive, "e--Documents-Work-strictlyelvisshow")
+    _slug_dir(archive, "e--dev-work-strictlyelvisshow")
+    project = tmp_path / "dev" / "work" / "strictlyelvisshow"
+    project.mkdir(parents=True)
+    report = orphan_slugs.run_orphan_check(
+        archive, explicit_paths=[project],
+    )
+    out = orphan_slugs.format_report(report)
+    assert "[ERROR]" in out
+    assert "claude-recall migrate" in out
+
+
+def test_format_report_renders_clean_message(tmp_path):
+    archive = tmp_path / "projects"
+    archive.mkdir()
+    out = orphan_slugs.format_report(
+        orphan_slugs.run_orphan_check(archive),
+    )
+    assert "no orphans" in out.lower()


### PR DESCRIPTION
## Summary

Adds `claude-recall orphan-slugs` to surface the failure mode that produced yesterday's strictlyelvisshow data-loss incident: a bulk-migration script moved project directories but left some claude-recall slug archives stranded under their pre-migration names. The sessions sat unreachable from any current project path; the following day's disk cleanup deleted the only remaining backup. Backblaze saved us, but the failure mode was preventable.

**Stacked on top of #31** (`feat/scrub-images`). Merge #31 first, then this.

## What it catches

Three categories with severity-based exit codes:

- **ERROR (exit 2)** — pre-migration slug with a live successor. Prints the exact `claude-recall migrate --from X --to Y` command needed to merge the history. Successor heuristic matches by trailing project-name segment across both filesystem slugs AND expected slugs (so a successor that hasn't accumulated sessions yet still matches).
- **WARN (exit 1)** — orphan slug with no apparent successor. Sessions intact but unreachable; decision left to the user.
- **OK (exit 0)** — expected path with no archive yet. Informational only (Claude Code creates the slug on first session).

## Real-world validation

Smoke-test against the live archive surfaced **3 actionable pre-migration migrations** that the May 26 script missed:

```
[ERROR] 3 pre-migration slug(s) with a live successor — action recommended:
  - e--Documents-Hobbies-Scrivener-Full-Export-Manuscript-FULL → e--dev-personal-Manuscript-FULL
  - e--Documents-Work-Performance-code-analysis → e--dev-work-WEC-Performance-code-analysis
  - e--Documents-Work-Performance-messaging-api → e--dev-work-WEC-Performance-messaging-api
```

Plus 4 WARN-level orphans worth reviewing (`MQ`, `rwmgallery`, the `kevin-laptop-case` and `SkullUp` cases where the reverse-slug parser hits dashes-vs-slashes ambiguity).

## Usage

```bash
# Auto-detect Project Manager projects.json on Windows.
claude-recall orphan-slugs

# Declare project roots explicitly.
claude-recall orphan-slugs \
  --projects-root e:/dev/work \
  --projects-root e:/dev/personal \
  --projects-root e:/dev/school

# Point at an explicit projects.json.
claude-recall orphan-slugs --projects-json /path/to/projects.json
```

## Inputs (any combination)

- `--projects-json` — Project Manager-style JSON. Windows: auto-detected at `%APPDATA%/Code/User/globalStorage/alefragnani.project-manager/projects.json`.
- `--path` (repeatable) — explicit expected project paths.
- `--projects-root` (repeatable) — directory tiers whose immediate children are projects (e.g., `e:/dev/work`).

Without any input, runs in filesystem-only mode (every slug must reverse-resolve to an existing path; otherwise it's flagged).

## What it does NOT do

- Doesn't auto-migrate. The recommended `claude-recall migrate` command is printed; the user runs it. Auto-migration could merge the wrong history if the successor heuristic guesses wrong.
- Doesn't handle slugs whose path-segment encoding differs from `slug_from_path`'s output (e.g., `com.efun.euklqb` — dots may be collapsed in the actual slug). Workaround: pass the live path via `--path` to match directly.

## Test plan

- [x] 21 new unit tests covering reverse parser, projects.json reading (placeholder + malformed + dedup), pre-migration detection, successor heuristic (including the expected-slug-only case from Manuscript-FULL), end-to-end scans (orphan / pre-migration / clean / missing), projects.json + projects-root inputs, report formatting
- [x] Full suite: 324 pass / 1 skip, zero regressions
- [x] Smoke test against the live archive — found 3 actionable + 4 informational findings, all reasonable

🤖 Generated with [Claude Code](https://claude.com/claude-code)